### PR TITLE
SKlearn、TensorFlow 训练时，支持回显

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/com/hortonworks/spark/sql/kafka08/KafkaOperator.scala
+++ b/streamingpro-spark-2.0/src/main/java/com/hortonworks/spark/sql/kafka08/KafkaOperator.scala
@@ -1,0 +1,30 @@
+package com.hortonworks.spark.sql.kafka08
+
+import java.util.Properties
+
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+
+/**
+  * Created by allwefantasy on 23/4/2018.
+  */
+object KafkaOperator {
+  def writeKafka(kafkaParam: Map[String, String], lines: Iterator[String]) = {
+
+    val topic = kafkaParam("userName") + "_training_msg"
+
+    val props = new Properties()
+    kafkaParam.foreach(f => props.put(f._1, f._2))
+
+
+    props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+    props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+    val producer = new KafkaProducer[String, String](props)
+    try {
+      lines.foreach { line =>
+        producer.send(new ProducerRecord[String, String](topic, line))
+      }
+    } finally {
+      producer.close()
+    }
+  }
+}

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLSKLearn.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLSKLearn.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.nio.file.{Files, Paths}
 import java.util
 
+import com.hortonworks.spark.sql.kafka08.KafkaOperator
 import org.apache.commons.io.FileUtils
 import org.apache.spark.TaskContext
 import org.apache.spark.api.python.WowPythonRunner
@@ -66,7 +67,13 @@ class SQLSKLearn extends SQLAlg with Functions {
         sk_bayes,
         userFileName, modelPath = path
       )
-      res.foreach(f => f)
+
+      if (!kafkaParam.contains("userName")) {
+        res.foreach(f => f)
+      } else {
+        KafkaOperator.writeKafka(kafkaParam, res)
+      }
+
       //读取模型文件，保存到hdfs上，方便下次获取
       val file = new File(new File(tempModelLocalPath), "model.pickle")
       val byteArray = Files.readAllBytes(Paths.get(file.getPath))

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLTensorFlow.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLTensorFlow.scala
@@ -6,6 +6,7 @@ import java.io.{ByteArrayOutputStream, File}
 import java.util
 import java.util.Properties
 
+import com.hortonworks.spark.sql.kafka08.KafkaOperator
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -104,7 +105,14 @@ class SQLTensorFlow extends SQLAlg with Functions {
         tfSource,
         tfName, modelPath = path, validateData = rowsBr.value
       )
-      res.foreach(f => f)
+
+      if (!kafkaParam.contains("userName")) {
+        res.foreach(f => f)
+      } else {
+        KafkaOperator.writeKafka(kafkaParam, res)
+      }
+
+
       val fs = FileSystem.get(new Configuration())
       //delete model path
       //      if (fs.exists(new Path(path))) {


### PR DESCRIPTION
在使用SKlearn /TensorFlow 做训练时，只要train 配置了kafkaParam.userName参数，对应的标准输出会写入到Kafka,比如下面的例子：

```sql
-- tensorflow

load libsvm.`/Users/allwefantasy/Softwares/spark-2.2.0-bin-hadoop2.7/data/mllib/sample_libsvm_data.txt` as data;

train data as TensorFlow.`/tmp/model` 
where pythonDescPath="/Users/allwefantasy/CSDNWorkSpace/streamingpro/streamingpro-spark-2.0/src/main/resources-local/python/example.py"
and  `kafkaParam.bootstrap.servers`="127.0.0.1:9092"
and   `kafkaParam.topic`="test"
and   `kafkaParam.group_id`="g_test-1"
and   `kafkaParam.reuse`="false"
and   `kafkaParam.userName`="william"
and `fitParam.0.epochs`="10"
and  `fitParam.0.max_records`="10"
and `systemParam.pythonPath`="python";

```
此时会新生成一个`william_training_msg` 的主题。example.py 脚本的所有标准输出都会写入到william_training_msg里。

使用

```
kafka-console-consumer --zookeeper localhost:2181 --topic william_training_msg
```
即可在终端看到训练过程。方便web界面能够实时回显。如果没有配置kafkaParam.userName，则对应的日志会混在executor的日志里。