### PR TITLE
PythonAlgBP模块

### DIFF
--- a/docs/en/mlsql-build-in-algorithms.md
+++ b/docs/en/mlsql-build-in-algorithms.md
@@ -40,7 +40,11 @@
 ### TfIdfInPlace
 
 TF/IDF is really widespread used in NLP classification job. 
-TfIdfInPlace module is a implementation of tf/idf where the target is  to convert raw text to vector.
+TfIdfInPlace can be used to convert raw text to vector with tf/idf.
+
+A list of numeric is represented by Vector in StreamingPro  which is can be feed to many algorithms directly, and the element in vector 
+normally  is double type.
+
 The processing steps include:
 
 1. text analysis
@@ -50,6 +54,7 @@ The processing steps include:
 5. compute idf/tf
 6. weighted specified words
 
+You can control how this module work by tuning the parameters TfIdfInPlace exposes. 
 
 Example:
 
@@ -81,6 +86,19 @@ load parquet.`/tmp/tfidf/data` as lwys_corpus_with_featurize;
 -- register the model as predict function so we can use it in batch/stream/api applications 
 register TfIdfInPlace.`/tmp/tfidfinplace` as predict;
 ```
+
+
+Parameters:
+
+|Parameter|Default|Comments|
+|:----|:----|:----|
+|inputCol|Which text column you want to process||
+|resultFeature|None|flag:concat m n-dim arrays to one m*n-dim array;merge: merge multi n-dim arrays into one n-dim array；index: output of conword sequence|
+|dicPaths|None|user-defined dictionary|
+|stopWordPath|user-defined stop word dictionary||
+|priority||how much weight should be applied in priority words|
+|nGram|None|ngram，we can compose 2 or 3 words together so maby the new complex features can more succinctly capture importtant information in raw data. Note that too much ngram composition may increase feature space too much , this makes it hard to compute.|
+|split|optinal, a token specifying how to analysis the text string||
 
 
 ### Word2VecInPlace

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -81,9 +81,11 @@ object MLMapping {
     "JavaImage" -> "streaming.dsl.mmlib.algs.processing.SQLJavaImage",
     "Discretizer" -> "streaming.dsl.mmlib.algs.SQLDiscretizer",
     "SendMessage" -> "streaming.dsl.mmlib.algs.SQLSendMessage",
+    "JDBC" -> "streaming.dsl.mmlib.algs.SQLJDBC",
     "VecMapInPlace" -> "streaming.dsl.mmlib.algs.SQLVecMapInPlace",
     "DTFAlg" -> "streaming.dsl.mmlib.algs.SQLDTFAlg",
-    "Map" -> "streaming.dsl.mmlib.algs.SQLMap"
+    "Map" -> "streaming.dsl.mmlib.algs.SQLMap",
+    "PythonAlgBP" -> "streaming.dsl.mmlib.algs.SQLPythonAlgBatchPrediction"
   )
 
   def findAlg(name: String) = {

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLJDBC.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLJDBC.scala
@@ -1,0 +1,55 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import streaming.dsl.ScriptSQLExec
+import streaming.dsl.mmlib.SQLAlg
+import streaming.log.Logging
+
+/**
+  * Created by allwefantasy on 25/8/2018.
+  */
+class SQLJDBC extends SQLAlg with MllibFunctions with Functions with Logging {
+
+  def executeInDriver(options: Map[String, String]) = {
+    val driver = options("driver")
+    val url = options("url")
+    Class.forName(driver)
+    val connection = java.sql.DriverManager.getConnection(url, options("user"), options("password"))
+    try {
+      // we suppose that there is only one create if
+      val statements = options.filter(f =>"""driver\-statement\-[0-9]+""".r.findFirstMatchIn(f._1).nonEmpty).
+        map(f => (f._1.split("-").last.toInt, f._2)).toSeq.sortBy(f => f._1).map(f => f._2).map { f =>
+        logInfo(s"${getClass.getName} execute: ${f}")
+        connection.prepareStatement(f)
+      }
+
+      statements.map { f =>
+        f.execute()
+        f
+      }.map(_.close())
+    } finally {
+      if (connection != null)
+        connection.close()
+    }
+
+  }
+
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    var _params = params
+    if (ScriptSQLExec.dbMapping.containsKey(path)) {
+      ScriptSQLExec.dbMapping.get(path).foreach { f =>
+        _params = _params + (f._1 -> f._2)
+      }
+    }
+    executeInDriver(_params)
+  }
+
+  override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
+    throw new RuntimeException(s"${getClass.getName} not support register ")
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String, params: Map[String, String]): UserDefinedFunction = {
+    throw new RuntimeException(s"${getClass.getName} not support predict function.")
+  }
+}

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLPythonAlgBatchPrediction.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLPythonAlgBatchPrediction.scala
@@ -1,0 +1,168 @@
+package streaming.dsl.mmlib.algs
+
+import java.io.File
+import java.nio.charset.Charset
+import java.nio.file.{Files, Paths}
+import java.util
+import java.util.UUID
+
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql.execution.datasources.json.WowJsonInferSchema
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import org.apache.spark.util.{ExternalCommandRunner}
+import streaming.common.HDFSOperator
+import streaming.dsl.mmlib.SQLAlg
+import streaming.dsl.mmlib.algs.SQLPythonFunc._
+
+import scala.collection.JavaConverters._
+
+/**
+  * Created by allwefantasy on 5/2/2018.
+  * This Module support training or predicting with user-defined python script
+  */
+class SQLPythonAlgBatchPrediction extends SQLAlg with Functions {
+  override def train(df: DataFrame, wowPath: String, params: Map[String, String]): Unit = {
+
+    val kafkaParam = mapParams("kafkaParam", params)
+
+    require(kafkaParam.size > 0, "kafkaParam should be configured")
+
+    val systemParam = mapParams("systemParam", params)
+    val fitParam = mapParams("fitParam", params)
+
+    require(fitParam.size > 0, "fitParam should be configured")
+
+    val userPythonScript = loadUserDefinePythonScript(params, df.sparkSession)
+
+    val schema = df.schema
+
+    // load resource
+    var resourceParams = Map.empty[String, String]
+    if (fitParam.keys.map(_.split("\\.")(0)).toSet.contains("resource")) {
+      val resources = Functions.mapParams(s"resource", fitParam)
+      resources.foreach {
+        case (resourceName, resourcePath) =>
+          val tempResourceLocalPath = SQLPythonFunc.getLocalTempResourcePath(resourcePath, resourceName)
+          recordUserLog(kafkaParam, s"resource paramter found,system will load resource ${resourcePath} in ${tempResourceLocalPath} in executor.")
+          HDFSOperator.copyToLocalFile(tempResourceLocalPath, resourcePath, true)
+          resourceParams += (resourceName -> tempResourceLocalPath)
+          recordUserLog(kafkaParam, s"resource loaded.")
+      }
+    }
+
+
+    val sessionLocalTimeZone = df.sparkSession.sessionState.conf.sessionLocalTimeZone
+
+
+    val wowRDD = df.rdd.mapPartitionsWithIndex { (algIndex, data) =>
+
+      val pythonPath = systemParam.getOrElse("pythonPath", "python")
+      val pythonVer = systemParam.getOrElse("pythonVer", "2.7")
+      val pythonParam = systemParam.getOrElse("pythonParam", "").split(",").filterNot(f => f.isEmpty)
+      val hdfsModelPath = fitParam("modelPath")
+
+      val tempDataLocalPath = SQLPythonFunc.getLocalTempDataPath(wowPath)
+      val tempModelLocalPath = s"${SQLPythonFunc.getLocalBasePath}/${UUID.randomUUID().toString}/${algIndex}"
+      val tempResultLocalPath = s"${SQLPythonFunc.getLocalBasePath}/${UUID.randomUUID().toString}/${algIndex}"
+      val resultHDFSPath = s"${wowPath}/data"
+
+      val fs = FileSystem.get(new Configuration())
+      fs.copyToLocalFile(new Path(hdfsModelPath),
+        new Path(tempModelLocalPath))
+
+      var tempDataLocalPathWithAlgSuffix = tempDataLocalPath
+      tempDataLocalPathWithAlgSuffix = tempDataLocalPathWithAlgSuffix + "/" + algIndex
+      FileUtils.forceMkdir(new File(tempDataLocalPathWithAlgSuffix))
+
+      //here we write data to local
+      val fileWriter = Files.newBufferedWriter(Paths.get(tempDataLocalPathWithAlgSuffix + "/0.json"), Charset.forName("utf-8"))
+      try {
+        WowJsonInferSchema.toJson(data, schema, sessionLocalTimeZone, json => {
+          fileWriter.write(json)
+          fileWriter.newLine()
+        })
+        fileWriter.flush()
+      } finally {
+        fileWriter.close()
+      }
+
+
+      val paramMap = new util.HashMap[String, Object]()
+      val pythonScript = findPythonScript(userPythonScript, fitParam, "sk")
+
+      paramMap.put("fitParam", fitParam.asJava)
+
+      val kafkaP = kafkaParam + ("group_id" -> (kafkaParam("group_id") + "_" + algIndex))
+      paramMap.put("kafkaParam", kafkaP.asJava)
+
+      val internalSystemParam = Map(
+        "tempModelLocalPath" -> tempModelLocalPath,
+        "tempDataLocalPath" -> tempDataLocalPathWithAlgSuffix,
+        "tempResultLocalPath" -> tempResultLocalPath,
+        "resource" -> resourceParams.asJava
+      )
+
+      paramMap.put("internalSystemParam", internalSystemParam.asJava)
+      paramMap.put("systemParam", systemParam.asJava)
+
+
+      val command = Seq(pythonPath) ++ pythonParam ++ Seq(pythonScript.fileName)
+
+      val modelTrainStartTime = System.currentTimeMillis()
+
+      var score = 0.0
+      var trainFailFlag = false
+
+      try {
+        val res = ExternalCommandRunner.run(
+          command = command,
+          iter = paramMap,
+          schema = MapType(StringType, MapType(StringType, StringType)),
+          scriptContent = pythonScript.fileContent,
+          scriptName = pythonScript.fileName,
+          recordLog = SQLPythonFunc.recordAnyLog(kafkaParam),
+          modelPath = "", validateData = Array()
+        )
+
+        score = recordUserLog(algIndex, pythonScript, kafkaParam, res)
+      } catch {
+        case e: Exception =>
+          e.printStackTrace()
+          trainFailFlag = true
+      }
+
+      try {
+        //模型保存到hdfs上
+        fs.delete(new Path(resultHDFSPath), true)
+        fs.copyFromLocalFile(new Path(tempResultLocalPath),
+          new Path(resultHDFSPath))
+      } catch {
+        case e: Exception =>
+          e.printStackTrace()
+          trainFailFlag = true
+      } finally {
+        // delete local model
+        FileUtils.deleteDirectory(new File(tempModelLocalPath))
+        // delete local data
+        FileUtils.deleteDirectory(new File(tempDataLocalPathWithAlgSuffix))
+      }
+
+      Seq().toIterator
+    }
+    wowRDD.count()
+  }
+
+  override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
+    throw new RuntimeException(s"${getClass.getName} not support register ")
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String, params: Map[String, String]): UserDefinedFunction = {
+    throw new RuntimeException(s"${getClass.getName} not support predict function.")
+  }
+}

--- a/streamingpro-mlsql/src/main/resources-local/test/sql/python-alg-batch-predict.sql
+++ b/streamingpro-mlsql/src/main/resources-local/test/sql/python-alg-batch-predict.sql
@@ -1,0 +1,15 @@
+load libsvm.`sample_libsvm_data.txt` as data;
+
+train data as PythonAlgBP.`${path}`
+where
+pythonScriptPath="${pythonScriptPath}"
+
+and `kafkaParam.bootstrap.servers`="127.0.0.1:9092"
+and `kafkaParam.topic`="test"
+and `kafkaParam.group_id`="g_test-1"
+
+and  `fitParam.modelPath`="${modelPath}"
+
+and `systemParam.pythonPath`="python"
+and `systemParam.pythonVer`="2.7"
+;

--- a/streamingpro-mlsql/src/test/scala/streaming/core/DslSpec.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/core/DslSpec.scala
@@ -332,6 +332,29 @@ class DslSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQLConf
     }
   }
 
+//  "SQLJDBC" should "work fine" taggedAs (NotToRunTag) in {
+//
+//    withBatchContext(setupBatchContext(batchParamsWithCarbondata, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
+//      //执行sql
+//      implicit val spark = runtime.sparkSession
+//      val sq = createSSEL
+//
+//      ScriptSQLExec.parse(
+//        """
+//          |connect jdbc where
+//          |driver="com.mysql.jdbc.Driver"
+//          |and url="jdbc:mysql://127.0.0.1:3306/wow"
+//          |and driver="com.mysql.jdbc.Driver"
+//          |and user="root"
+//          |and password="----"
+//          |as mysql1;
+//          |select 1 as t as fakeTable;
+//          |train fakeTable JDBC.`mysql1` where
+//          |driver-statement-0="drop table test1"
+//        """.stripMargin, sq)
+//    }
+//  }
+
 }
 
 

--- a/streamingpro-mlsql/src/test/scala/streaming/core/PythonMLSpec.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/core/PythonMLSpec.scala
@@ -322,5 +322,7 @@ class PythonMLSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQ
       spark.sql("select * from newdata").show()
       assume(APIDeployPythonRunnerEnv.workerSize > 0)
     }
+
+
   }
 }

--- a/streamingpro-mlsql/src/test/scala/streaming/core/PythonMLSpec2.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/core/PythonMLSpec2.scala
@@ -1,0 +1,48 @@
+package streaming.core
+
+import java.io.File
+
+import org.apache.spark.APIDeployPythonRunnerEnv
+import org.apache.spark.streaming.BasicSparkOperation
+import streaming.common.shell.ShellCommand
+import streaming.core.code.PythonCode
+import streaming.core.strategy.platform.SparkRuntime
+import streaming.dsl.ScriptSQLExec
+import streaming.dsl.template.TemplateMerge
+
+/**
+  * Created by allwefantasy on 26/5/2018.
+  */
+class PythonMLSpec2 extends BasicSparkOperation with SpecFunctions with BasicMLSQLConfig {
+
+  copySampleLibsvmData
+
+  "SQLPythonAlgBatchPrediction" should "work fine" in {
+    withBatchContext(setupBatchContext(batchParams, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
+      //执行sql
+      implicit val spark = runtime.sparkSession
+      val sq = createSSEL
+
+      writeStringToFile("/tmp/sklearn-user-script.py", PythonCode.pythonCodeEnableLocal)
+      writeStringToFile("/tmp/sklearn-user-predict-script.py", PythonCode.pythonBatchPredictCode)
+
+      ShellCommand.exec("rm -rf /tmp/william/pa_model_k")
+
+      ScriptSQLExec.parse(TemplateMerge.merge(loadSQLScriptStr("python-alg-script-enable-data-local"), Map(
+        "pythonScriptPath" -> "/tmp/sklearn-user-script.py",
+        "keepVersion" -> "true",
+        "path" -> "/pa_model_k",
+        "distributeEveryExecutor" -> "false"
+
+      )), sq)
+
+      ScriptSQLExec.parse(TemplateMerge.merge(loadSQLScriptStr("python-alg-batch-predict"), Map(
+        "pythonScriptPath" -> "/tmp/sklearn-user-predict-script.py",
+        "modelPath" -> "/tmp/william/pa_model_k"
+      )), sq)
+
+
+    }
+  }
+
+}

--- a/streamingpro-mlsql/src/test/scala/streaming/core/PythonMLSpec2.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/core/PythonMLSpec2.scala
@@ -17,7 +17,7 @@ class PythonMLSpec2 extends BasicSparkOperation with SpecFunctions with BasicMLS
 
   copySampleLibsvmData
 
-  "SQLPythonAlgBatchPrediction" should "work fine" in {
+  "SQLPythonAlgBatchPrediction" should "work fine" taggedAs (NotToRunTag) in {
     withBatchContext(setupBatchContext(batchParams, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
       //执行sql
       implicit val spark = runtime.sparkSession


### PR DESCRIPTION
使用示例：

```sql
load libsvm.`sample_libsvm_data.txt` as data;

train data as PythonAlgBP.`${path}`
where
pythonScriptPath="${pythonScriptPath}"

and `kafkaParam.bootstrap.servers`="127.0.0.1:9092"
and `kafkaParam.topic`="test"
and `kafkaParam.group_id`="g_test-1"

and  `fitParam.modelPath`="${modelPath}"

and `systemParam.pythonPath`="python"
and `systemParam.pythonVer`="2.7"
;
```

pythonScript:

```python
from pyspark.ml.linalg import VectorUDT, Vectors
import pickle
import os
import mlsql
import json

tempDataLocalPath = mlsql.internal_system_param["tempDataLocalPath"]
tempModelLocalPath = mlsql.internal_system_param["tempModelLocalPath"]
tempResultLocalPath = mlsql.internal_system_param["tempResultLocalPath"]

print(tempDataLocalPath)
files = [file for file in os.listdir(tempDataLocalPath) if file.endswith(".json")]
res = []
for file in files:
    with open(tempDataLocalPath + "/" + file) as f:
        for line in f.readlines():
            obj = json.loads(line)
            f_size = obj["features"]["size"]
            f_indices = obj["features"]["indices"]
            f_values = obj["features"]["values"]
            res.append(Vectors.sparse(f_size, f_indices, f_values).toArray())
model = pickle.load(open(tempModelLocalPath+"/_model_0/model/0//model.pickle"))
model.predict(res)

if not os.path.exists(tempResultLocalPath):
    os.makedirs(tempResultLocalPath)

with open(tempResultLocalPath+"/0.json","w") as f:
    f.write("{}")
```
