### PR TITLE
[update] save/load 语句支持表为变量

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/LoadAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/LoadAdaptor.scala
@@ -36,7 +36,7 @@ class LoadAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
           path = s.getText
 
         case s: TableNameContext =>
-          tableName = s.getText
+          tableName = evaluate(s.getText)
         case _ =>
       }
     }

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/SaveAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/SaveAdaptor.scala
@@ -53,8 +53,8 @@ class SaveAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
           final_path = TemplateMerge.merge(final_path, scriptSQLExecListener.env().toMap)
 
         case s: TableNameContext =>
-          tableName = s.getText
-          oldDF = scriptSQLExecListener.sparkSession.table(s.getText)
+          tableName = evaluate(s.getText)
+          oldDF = scriptSQLExecListener.sparkSession.table(tableName)
         case s: OverwriteContext =>
           mode = SaveMode.Overwrite
         case s: AppendContext =>


### PR DESCRIPTION
```sql
set table1="jack";
select "a" as a as `${table1}`;
select *  from jack as output;
```

```sql
set table1="jack";
select "a" as a as `${table1}`;
save overwrite `${table1}` as parquet.`/tmp/jack`;
load parquet.`/tmp/jack` as jackm;
select *  from jackm as output;
```