### PR TITLE
add prediction result evaluation extension

### DIFF
--- a/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/TrainAdaptor.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/TrainAdaptor.scala
@@ -175,7 +175,8 @@ object MLMapping extends Logging with WowLog {
     "UploadFileToServerExt" -> "streaming.dsl.mmlib.algs.SQLUploadFileToServerExt",
     "WaterMarkInPlace" -> "streaming.dsl.mmlib.algs.SQLWaterMarkInPlace",
     "Word2ArrayInPlace" -> "streaming.dsl.mmlib.algs.SQLWord2ArrayInPlace",
-    "AutoML" -> "tech.mlsql.ets.algs.SQLAutoML"
+    "AutoML" -> "tech.mlsql.ets.algs.SQLAutoML",
+    "PredictionEva"->"streaming.dsl.mmlib.algs.SQLPredictionEva"
   )
 
   /**

--- a/streamingpro-it/src/test/resources/sql/simple/14_run_prediction_evaluation.mlsql
+++ b/streamingpro-it/src/test/resources/sql/simple/14_run_prediction_evaluation.mlsql
@@ -1,0 +1,16 @@
+--%comparator=tech.mlsql.it.IgnoreResultComparator
+-- create test data
+set jsonStr='''
+{"probability":{"type":1,"values":[0,1]},"label":0.0},
+{"probability":{"type":1,"values":[1.1747056153273105e-18,1]},"label":1.0}
+{"probability":{"type":1,"values":[1,0]},"label":0.0}
+{"probability":{"type":1,"values":[0.2,0.8]},"label":1.0}
+{"probability":{"type":1,"values":[0.5,0.5]},"label":1.0}
+{"probability":{"type":1,"values":[0.1,0.9]},"label":1.0}
+''';
+load jsonStr.`jsonStr` as data;
+-- extract the probability from the values
+select replace(String(probability), "[","") as prob, label from data as res1;
+select replace(prob, "]", "") as prob, label from res1 as res2;
+select Double(split(prob, ",")[1]) as prob, label from res2 as res3;
+run res3 as PredictionEva.`` where labelCol='label' and probCol='prob';

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLLogisticRegression.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLLogisticRegression.scala
@@ -136,7 +136,6 @@ class SQLLogisticRegression(override val uid: String) extends SQLAlg with MllibF
         Seq("uid", model.uid),
         Seq("numFeatures", model.numFeatures.toString),
         Seq("numClasses", model.numClasses.toString),
-        Seq("binarySummary", model.binarySummary.toString()),
         Seq("intercept", model.intercept.toString()),
         Seq("coefficients", model.coefficients.toString())
       ) ++ modelParams

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLNormalizeInPlace.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLNormalizeInPlace.scala
@@ -110,7 +110,9 @@ class SQLNormalizeInPlace(override val uid: String) extends SQLAlg with Function
           |""".stripMargin,
       label = "",
       options = Map(
-        "valueType" -> "string"
+        "valueType" -> "string",
+        "required" -> "true",
+        "derivedType" -> "NONE"
       )))
   ))
 

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLPredictionEva.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLPredictionEva.scala
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streaming.dsl.mmlib.algs
+
+
+import org.apache.spark.ml.param.Param
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+import streaming.dsl.mmlib.{Code, Doc, HtmlDoc, SQLAlg, SQLCode}
+import streaming.dsl.mmlib.algs.param.BaseParams
+import tech.mlsql.common.form.{Extra, FormParams, KV, Select, Text}
+import org.apache.spark.mllib.evaluation.{BinaryClassificationMetrics, MulticlassMetrics}
+import org.apache.spark.mllib.rdd.RDDFunctions.fromRDD
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.util.StringUtils
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import tech.mlsql.autosuggest.app.Standalone.sparkSession
+
+import scala.Array.ofDim
+
+/**
+ * Created by allwefantasy on 24/7/2018.
+ */
+class SQLPredictionEva(override val uid: String) extends SQLAlg with MllibFunctions with Functions with BaseParams {
+
+  def this() = this(BaseParams.randomUID())
+
+  private def binaryClassificationEvaluation(df: DataFrame, params: Map[String, String]): DataFrame = {
+    val spark = df.sparkSession
+    import spark.implicits._
+    val labelCol = params.getOrElse("labelCol", "label")
+    val labelVal = params.getOrElse("labelValue", 1.0)
+    val probCol = params.getOrElse("probCol", "prob")
+    val predictionDf = df.select(probCol, labelCol)
+    val predictionRdd = predictionDf.as[(Double, Double)].rdd
+    val binaryClassMetrics = new BinaryClassificationMetrics(predictionRdd)
+    //    val accuracy = binaryClassMe
+    val threshold = params.getOrElse("threshold", 0.5).asInstanceOf[Double]
+    val TP = predictionDf.filter(s"$probCol>=$threshold and $labelCol==$labelVal").count().toDouble
+    val FP = predictionDf.filter(s"$probCol>=$threshold and $labelCol!=$labelVal").count().toDouble
+    val TN = predictionDf.filter(s"$probCol<$threshold and $labelCol!=$labelVal").count().toDouble
+    val FN = predictionDf.filter(s"$probCol<$threshold and $labelCol==$labelVal").count().toDouble
+    val precision = TP / (TP + FP)
+    val recall = TP / (TP + FN)
+    val f1 = 2 * TP / (2 * TP + FP + FN)
+    val auc = binaryClassMetrics.areaUnderROC()
+    val prc = binaryClassMetrics.areaUnderPR()
+    val rows = Seq(
+      Seq("threshold", threshold.toString),
+      Seq("precision", precision.toString),
+      Seq("recall", recall.toString),
+      Seq("f1", f1.toString),
+      Seq("auc", auc.toString),
+      Seq("prc", prc.toString)
+    ).map(Row.fromSeq(_))
+    spark.createDataFrame(spark.sparkContext.parallelize(rows, 1),
+      StructType(Seq(StructField("metrics", StringType), StructField("value", StringType)))
+    )
+  }
+
+  override def train(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
+    binaryClassificationEvaluation(df, params)
+  }
+
+  override def explainParams(sparkSession: SparkSession): DataFrame = {
+    _explainParams(sparkSession)
+  }
+
+  final val labelCol: Param[String] = new Param[String](this, "labelCol", FormParams.toJson(Text(
+    name = "labelCol",
+    value = "",
+    extra = Extra(
+      doc =
+        """
+          |Specify the column name that contains the prediction result
+          |""".stripMargin,
+      label = "",
+      options = Map(
+        "valueType" -> "string",
+        "defaultValue" -> "label",
+        "required" -> "true",
+        "derivedType" -> "NONE"
+      )))
+  ))
+
+  final val labelVal: Param[String] = new Param[String](this, "labelVal", FormParams.toJson(Text(
+    name = "labelVal",
+    value = "",
+    extra = Extra(
+      doc =
+        """
+          |Specify the value reveals the positive samples.
+          |""".stripMargin,
+      label = "",
+      options = Map(
+        "valueType" -> "double",
+        "defaultValue" -> "1.0",
+        "required" -> "false",
+        "derivedType" -> "NONE"
+      )))
+  ))
+
+  final val probCol: Param[String] = new Param[String](this, "probCol", FormParams.toJson(Text(
+    name = "probCol",
+    value = "",
+    extra = Extra(
+      doc =
+        """
+          |Specify the column of the probability value.
+          |""".stripMargin,
+      label = "",
+      options = Map(
+        "valueType" -> "string",
+        "defaultValue" -> "prob",
+        "required" -> "true",
+        "derivedType" -> "NONE"
+      )))
+  ))
+
+  final val threshold: Param[String] = new Param[String](this, "threshold", FormParams.toJson(Text(
+    name = "threshold",
+    value = "0.5",
+    extra = Extra(
+      doc =
+        """
+          | The value that defines whether a sample record is positive or not.
+          |""".stripMargin,
+      label = "",
+      options = Map(
+        "valueType" -> "double",
+        "defaultValue" -> "0.5",
+        "required" -> "false",
+        "derivedType" -> "NONE"
+      )))
+  ))
+
+  override def load(sparkSession: SparkSession, _path: String, params: Map[String, String]): Any = {
+    throw new RuntimeException("register is not supported in PredictionEva")
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String, params: Map[String, String]): UserDefinedFunction = {
+    throw new RuntimeException("register is not supported in PredictionEva")
+  }
+
+  override def codeExample: Code = Code(SQLCode, CodeExampleText.jsonStr +
+    """
+      |select replace(String(probability), "[","") as prob, label from res as res1;
+      |select replace(prob, "]", "") as prob, label from res1 as res2;
+      |select Double(split(prob, ",")[1]) as prob, label from res2 as res3;
+      |run res3 as PredictionEva.`` where labelCol='label' and probCol='prob';
+      |;
+    """.stripMargin)
+
+  override def doc: Doc = Doc(HtmlDoc,
+    """
+      | <a href="https://en.wikipedia.org/wiki/Evaluation_of_binary_classifiers"> PredictionEva </a> is an extension for evaluating the prediction result.
+      |
+      | It will evaluate the prediction results from f1-score, precision, recall, auc value and prc value.
+      |
+    """.stripMargin)
+}


### PR DESCRIPTION
# What changes were proposed in this pull request?
- [ ] This commit add an extension that could analyze and evaluate the binary classifiers performance. The extension evaluate the performance of binary models by f1-scores, confusion matrix, and auc value which are valuable for model evaluation before the deployment.

# How was this patch tested?
- [ ] The extension code is tested by the file named '14_run_prediction_evaluation.mlsql'.

# Are there and DOC need to update?
- [ ] Doc is finished
# Spark Core Compatibility
