### PR TITLE
Change input parameter data types in JsonExpandExt and SQLRateSampler

### DIFF
--- a/external/mlsql-ets/src/main/java/tech/mlsql/plugins/ets/JsonExpandExt.scala
+++ b/external/mlsql-ets/src/main/java/tech/mlsql/plugins/ets/JsonExpandExt.scala
@@ -64,7 +64,7 @@ class JsonExpandExt (override val uid: String) extends SQLAlg with WowParams wit
           doc = "SamplingRatio used by Spark to infer schema from json"
           , label = "samplingRatio"
           , options = Map(
-            "valueType" -> "string",
+            "valueType" -> "double",
             "required" -> "false",
             "derivedType" -> "NONE"
           )

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLRateSampler.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLRateSampler.scala
@@ -176,10 +176,10 @@ private class SQLRateSampler(override val uid: String) extends SQLAlg with Funct
 
   final val sampleRate: Param[String] = new Param[String](parent = this, name = "sampleRate",
     doc = FormParams.toJson( Text ( name = "sampleRate", value = "", extra = Extra(
-      doc = "comma delimited doubles, i.e 0.9,0.1"
+      doc = "comma delimited double array, i.e 0.9,0.1"
       , label = "sampleRate"
       , options = Map(
-        "valueType" -> "string",
+        "valueType" -> "array[double]",
         "required" -> "true",
         "derivedType" -> "NONE"
       ))


### PR DESCRIPTION
# What changes were proposed in this pull request?
- Change samplingRatio data type to double in JsonExpandExt
- Change sampleRate data type to array[double] in SQLRateSampler

# How was this patch tested?
- Manually checked data type

# Are there and DOC need to update?
- No doc changes

# Spark Core Compatibility
- No Spark compatibility changes