### PR TITLE
Support train and run syntax suggestions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,11 +19,8 @@
 
 name: Build and test
 
-on:
-  pull_request:
-    branches: [ main ]
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+on: pull_request
+
 jobs:
   # Build: build MLSQL and run the tests
   build:

--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/AutoSuggestContext.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/AutoSuggestContext.scala
@@ -199,6 +199,9 @@ class AutoSuggestContext(val session: SparkSession,
       case Some("set") =>
         val suggester = new SetSuggester(this, _statements(index), relativeTokenPos)
         suggester.suggest()
+      case Some("run") | Some("train") =>
+        val suggester = new TrainSuggester(this, _statements(index), relativeTokenPos)
+        suggester.suggest()
       case Some(value) => firstWords.filter(_.name.startsWith(value))
       case None => firstWords
     }

--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/SpecialTableConst.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/SpecialTableConst.scala
@@ -7,9 +7,14 @@ import tech.mlsql.autosuggest.meta.{MetaTable, MetaTableKey}
  */
 object SpecialTableConst {
   val KEY_WORD = "__KEY__WORD__"
+
   val DATA_SOURCE_KEY = "__DATA__SOURCE__"
+
   val OPTION_KEY = "__OPTION__"
+
   val TEMP_TABLE_DB_KEY = "__TEMP_TABLE__"
+
+  val ET_KEY = "__ET__"
 
   val OTHER_TABLE_KEY = "__OTHER__TABLE__"
 
@@ -18,6 +23,8 @@ object SpecialTableConst {
   def KEY_WORD_TABLE = MetaTable(MetaTableKey(None, None, SpecialTableConst.KEY_WORD), List())
 
   def DATA_SOURCE_TABLE = MetaTable(MetaTableKey(None, None, SpecialTableConst.DATA_SOURCE_KEY), List())
+
+  def ET_TABLE = MetaTable(MetaTableKey(None, None, SpecialTableConst.ET_KEY), List())
 
   def OPTION_TABLE = MetaTable(MetaTableKey(None, None, SpecialTableConst.OPTION_KEY), List())
 

--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/app/MLSQLAutoSuggestApp.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/app/MLSQLAutoSuggestApp.scala
@@ -82,7 +82,7 @@ class AutoSuggestController extends CustomController {
     val lineNum = params("lineNum").toInt
     val columnNum = params("columnNum").toInt
     val isDebug = params.getOrElse("isDebug", "false").toBoolean
-    val size = params.getOrElse("size", "30").toInt
+    val size = params.getOrElse("size", "100").toInt
     val includeTableMeta = params.getOrElse("includeTableMeta", "false").toBoolean
 
     val schemaInferUrl = params.getOrElse("schemaInferUrl", "")

--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/SetSuggester.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/SetSuggester.scala
@@ -58,7 +58,7 @@ class SetSuggester(val context: AutoSuggestContext, val _tokens: List[Token], va
     }
 
     _tokenPos match {
-      case TokenPos(pos, TokenPosType.CURRENT, _) if pos > 0 =>
+      case TokenPos(pos, TokenPosType.CURRENT, offsetInToken) if pos > 0 =>
         // The current pos is IDENTIFIER, and is the where prefix
         if ("where".startsWith(_tokens(pos).getText)) {
           items = List(SuggestItem("where", SpecialTableConst.KEY_WORD_TABLE, Map()))
@@ -117,7 +117,7 @@ private class SetOptionsSuggester(setSuggester: SetSuggester) extends SetSuggest
 
   override def isMatch(): Boolean = {
     if (tokenPos.currentOrNext == TokenPosType.CURRENT && !SET_OPTION_SUGGESTIONS.exists(
-      _.name.startsWith(tokens(tokenPos.pos).getText))) {
+      _.name.toUpperCase.startsWith(tokens(tokenPos.pos).getText.toUpperCase))) {
       return false
     }
 
@@ -133,13 +133,7 @@ private class SetOptionsSuggester(setSuggester: SetSuggester) extends SetSuggest
       val curOptionValue = tokens.slice(temp + 1, tokens.length).filter(item => item.getType == DSLSQLLexer.IDENTIFIER).map(_.getText)
       return SET_OPTION_SUGGESTIONS.filter(item => !curOptionValue.contains(item.name))
     }
-
     SET_OPTION_SUGGESTIONS
-  }
-
-  private def getOptionsIndex: Int = {
-    TokenMatcher(tokens, tokenPos.pos).back.orIndex(List(Food(None, DSLSQLLexer.WHERE),
-      Food(None, DSLSQLLexer.OPTIONS)).toArray)
   }
 }
 

--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/StatementSuggester.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/StatementSuggester.scala
@@ -1,5 +1,7 @@
 package tech.mlsql.autosuggest.statement
 
+import org.antlr.v4.runtime.Token
+import tech.mlsql.autosuggest.TokenPos
 import tech.mlsql.autosuggest.meta.MetaTable
 import tech.mlsql.common.utils.log.Logging
 
@@ -27,3 +29,9 @@ trait StatementSuggester extends Logging{
 }
 
 case class SuggestItem(name: String, metaTable: MetaTable, extra: Map[String, String])
+
+abstract class SuggesterBase(_tokens: List[Token], _tokenPos: TokenPos) extends StatementSuggester with StatementUtils {
+  override def tokens: List[Token] = _tokens
+
+  override def tokenPos: TokenPos = _tokenPos
+}

--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/StatementUtils.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/StatementUtils.scala
@@ -55,6 +55,11 @@ trait StatementUtils {
       None
     }
   }
+
+  def getOptionsIndex: Int = {
+    TokenMatcher(tokens, tokenPos.pos).back.orIndex(List(Food(None, DSLSQLLexer.WHERE),
+      Food(None, DSLSQLLexer.OPTIONS)).toArray)
+  }
 }
 
 object StatementUtils {

--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/TrainSuggester.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/TrainSuggester.scala
@@ -1,0 +1,236 @@
+package tech.mlsql.autosuggest.statement
+
+import org.antlr.v4.runtime.Token
+import streaming.dsl.mmlib.SQLAlg
+import streaming.dsl.parser.DSLSQLLexer
+import tech.mlsql.autosuggest.dsl.{Food, MLSQLTokenTypeWrapper, TokenMatcher}
+import tech.mlsql.autosuggest.statement.TrainSuggester.isTrainHeader
+import tech.mlsql.autosuggest.{AutoSuggestContext, SpecialTableConst, TokenPos, TokenPosType}
+import tech.mlsql.dsl.adaptor.MLMapping
+
+import scala.collection.mutable
+
+/**
+ * 21/10/2021 hellozepp(lisheng.zhanglin@163.com)
+ */
+class TrainSuggester(val context: AutoSuggestContext, val _tokens: List[Token], val _tokenPos: TokenPos) extends StatementSuggester
+  with SuggesterRegister with StatementUtils {
+
+  private val subInstances = new mutable.HashMap[String, StatementSuggester]()
+
+  register(classOf[TrainTempTableSuggester])
+  register(classOf[TrainFormatSuggester])
+  register(classOf[TrainPathQuoteSuggester])
+  register(classOf[TrainPathSuggester])
+  register(classOf[TrainOptionsSuggester])
+
+  override def register(clazz: Class[_ <: StatementSuggester]): SuggesterRegister = {
+    val instance = clazz.getConstructor(classOf[TrainSuggester]).newInstance(this)
+    subInstances.put(instance.name, instance)
+    this
+  }
+
+  override def isMatch(): Boolean = isTrainHeader(_tokens)
+
+
+  override def suggest(): List[SuggestItem] = {
+    keywordSuggest ++ defaultSuggest(subInstances.toMap)
+  }
+
+  private def keywordSuggest: List[SuggestItem] = {
+    var items = List[SuggestItem]()
+    // If the where keyword already exists, it will not prompt
+    if (backAndFirstIs(DSLSQLLexer.WHERE) || backAndFirstIs(DSLSQLLexer.OPTIONS)) {
+      return items
+    }
+
+    _tokenPos match {
+      case TokenPos(pos, TokenPosType.NEXT, _) =>
+        val temp = TokenMatcher(_tokens, pos).back.
+          eat(Food(None, DSLSQLLexer.BACKQUOTED_IDENTIFIER)).
+          eat(Food(None, MLSQLTokenTypeWrapper.DOT)).
+          build
+        if (temp.isSuccess) {
+          items = List(SuggestItem("where ", SpecialTableConst.KEY_WORD_TABLE, Map()),
+            SuggestItem("options ", SpecialTableConst.KEY_WORD_TABLE, Map()))
+        }
+        items
+      case TokenPos(pos, TokenPosType.CURRENT, _) =>
+        val temp = TokenMatcher(_tokens, pos - 1).back.
+          eat(Food(None, DSLSQLLexer.BACKQUOTED_IDENTIFIER)).
+          eat(Food(None, MLSQLTokenTypeWrapper.DOT)).
+          build
+        if (temp.isSuccess) {
+          items = List(SuggestItem("where ", SpecialTableConst.KEY_WORD_TABLE, Map()),
+            SuggestItem("options ", SpecialTableConst.KEY_WORD_TABLE, Map()))
+        }
+        items
+      case _ => List()
+    }
+
+  }
+
+  override def name: String = "train"
+
+  override def tokens: List[Token] = _tokens
+
+  override def tokenPos: TokenPos = _tokenPos
+}
+
+object TrainSuggester {
+  def isTrainHeader(_tokens: List[Token]): Boolean = {
+    _tokens.headOption.map(_.getType) match {
+      case Some(DSLSQLLexer.TRAIN) => true
+      case Some(DSLSQLLexer.RUN) => true
+      case _ => false
+    }
+  }
+}
+
+class TrainTempTableSuggester(trainSuggester: TrainSuggester) extends SuggesterBase(trainSuggester._tokens, trainSuggester._tokenPos) {
+  override def isMatch(): Boolean = {
+    if (tokenPos.currentOrNext == TokenPosType.CURRENT && trainSuggester.context.metaProvider.list().isEmpty) {
+      // pass
+    } else if (tokenPos.currentOrNext == TokenPosType.CURRENT && !trainSuggester.context.metaProvider.list().exists(table =>
+      table.key.table.toUpperCase().startsWith(tokens(tokenPos.pos).getText.toUpperCase) ||
+        "COMMAND".startsWith(tokens(tokenPos.pos).getText.toUpperCase))) {
+      return false
+    }
+
+    var skipSize = 0
+    if (tokenPos.currentOrNext == TokenPosType.CURRENT) {
+      skipSize = 1
+    }
+    if (tokenPos.pos - skipSize < 0) {
+      return false
+    }
+    TokenMatcher(tokens, tokenPos.pos - skipSize).back.eat(Food(None, DSLSQLLexer.TRAIN)).isSuccess ||
+      TokenMatcher(tokens, tokenPos.pos - skipSize).back.eat(Food(None, DSLSQLLexer.RUN)).isSuccess
+  }
+
+  override def suggest(): List[SuggestItem] = {
+    trainSuggester.context.metaProvider.list().filter(table => table.key.db == Option(SpecialTableConst.TEMP_TABLE_DB_KEY))
+      .map(table => SuggestItem(table.key.table + " as ", table, Map("desc" -> "temp table"))) ++
+      List(SuggestItem("command as ", SpecialTableConst.OTHER_TABLE, Map("desc" -> "command")))
+  }
+
+  override def name: String = "tempTable"
+}
+
+class TrainPathQuoteSuggester(trainSuggester: TrainSuggester) extends SuggesterBase(trainSuggester._tokens, trainSuggester._tokenPos) {
+
+  override def isMatch(): Boolean = {
+    TokenMatcher(tokens, tokenPos.pos).back.
+      eat(Food(None, MLSQLTokenTypeWrapper.DOT)).
+      eat(Food(None, DSLSQLLexer.IDENTIFIER)).
+      eat(Food(None, DSLSQLLexer.AS)).
+      eat(Food(None, DSLSQLLexer.IDENTIFIER)).
+      eat(Food(None, DSLSQLLexer.RUN))
+      .build.isSuccess ||
+      TokenMatcher(tokens, tokenPos.pos).back.
+        eat(Food(None, MLSQLTokenTypeWrapper.DOT)).
+        eat(Food(None, DSLSQLLexer.IDENTIFIER)).
+        eat(Food(None, DSLSQLLexer.AS)).
+        eat(Food(None, DSLSQLLexer.IDENTIFIER)).
+        eat(Food(None, DSLSQLLexer.TRAIN))
+        .build.isSuccess
+  }
+
+  override def suggest(): List[SuggestItem] = {
+    LexerUtils.filterPrefixIfNeeded(List(SuggestItem("``", SpecialTableConst.OTHER_TABLE, Map("desc" -> "path or table"))),
+      tokens, tokenPos)
+  }
+
+  override def name: String = "pathQuote"
+}
+
+//Here you can implement Hive table / HDFS Path auto suggestion
+class TrainPathSuggester(trainSuggester: TrainSuggester) extends SuggesterBase(trainSuggester._tokens, trainSuggester._tokenPos) {
+
+  override def isMatch(): Boolean = {
+    false
+  }
+
+  override def suggest(): List[SuggestItem] = {
+    List()
+  }
+
+  override def name: String = "path"
+
+}
+
+class TrainFormatSuggester(trainSuggester: TrainSuggester) extends SuggesterBase(trainSuggester._tokens, trainSuggester._tokenPos) {
+  override def isMatch(): Boolean = {
+    val etNames = MLMapping.getAllETNames
+    if (tokenPos.currentOrNext == TokenPosType.CURRENT && !etNames.exists(name =>
+      name.startsWith(tokens(tokenPos.pos).getText))) {
+      return false
+    }
+
+    var skipSize = 0
+    if (tokenPos.currentOrNext == TokenPosType.CURRENT) {
+      skipSize = 1
+    }
+    if (tokenPos.pos - skipSize < 0) {
+      return false
+    }
+    TokenMatcher(tokens, tokenPos.pos - skipSize).back.eat(Food(None, DSLSQLLexer.AS), Food(None, DSLSQLLexer.IDENTIFIER))
+      .eat(Food(None, DSLSQLLexer.RUN)).build.isSuccess ||
+      TokenMatcher(tokens, tokenPos.pos - skipSize).back.eat(Food(None, DSLSQLLexer.AS), Food(None, DSLSQLLexer.IDENTIFIER))
+        .eat(Food(None, DSLSQLLexer.TRAIN)).build.isSuccess
+  }
+
+  override def suggest(): List[SuggestItem] = {
+    // ET type suggest
+    val etNames = MLMapping.getAllETNames
+    LexerUtils.filterPrefixIfNeeded(
+      etNames.map(name => SuggestItem(s"$name.`` ", SpecialTableConst.ET_TABLE,
+        Map("desc" -> "ET"))).toList,
+      tokens, tokenPos)
+
+  }
+
+  override def name: String = "format"
+}
+
+class TrainOptionsSuggester(trainSuggester: TrainSuggester) extends SuggesterBase(trainSuggester._tokens, trainSuggester._tokenPos) {
+
+  override def isMatch(): Boolean = {
+    backAndFirstIs(DSLSQLLexer.OPTIONS) || backAndFirstIs(DSLSQLLexer.WHERE)
+  }
+
+  override def suggest(): List[SuggestItem] = {
+    var mapping: Map[String, SQLAlg] = null
+    if (tokens.size > 4) {
+      mapping = MLMapping.getETInstanceMapping
+      if (!mapping.contains(tokens(3).getText)) {
+        return List()
+      }
+    }
+    val etName = tokens(3).getText
+    val etParams = mapping(etName).explainParams(trainSuggester.context.session).collect().
+      map(row => (row.getString(0), row.getString(1))).
+      toBuffer
+
+    var res: List[SuggestItem] = List()
+    if (tokenPos.currentOrNext == TokenPosType.CURRENT) {
+      res = LexerUtils.filterPrefixIfNeeded(etParams.map(tuple =>
+        SuggestItem(s"${tuple._1}=", SpecialTableConst.OPTION_TABLE, Map("desc" -> tuple._2))).toList,
+        tokens, tokenPos)
+    } else if (tokens(tokenPos.pos).getType.equals(DSLSQLLexer.UNRECOGNIZED)) {
+      if (tokens(tokenPos.pos).getText.equals("`")) {
+        res = LexerUtils.filterPrefixIfNeeded(etParams.map(tuple =>
+          SuggestItem(s"${tuple._1}`=", SpecialTableConst.OPTION_TABLE, Map("desc" -> tuple._2))).toList,
+          tokens, tokenPos)
+      }
+    } else if (tokenPos.currentOrNext == TokenPosType.NEXT) {
+      res = LexerUtils.filterPrefixIfNeeded(etParams.map(tuple =>
+        SuggestItem(s"`${tuple._1}`=", SpecialTableConst.OPTION_TABLE, Map("desc" -> tuple._2))).toList,
+        tokens, tokenPos)
+    }
+    res ++ List(SuggestItem("and ", SpecialTableConst.KEY_WORD_TABLE, Map("desc" -> "and")),
+      SuggestItem("as ", SpecialTableConst.KEY_WORD_TABLE, Map("desc" -> "as")))
+  }
+
+  override def name: String = "options"
+}

--- a/external/mlsql-autosuggest/src/test/java/com/intigua/antlr4/autosuggest/TrainSuggesterTest.scala
+++ b/external/mlsql-autosuggest/src/test/java/com/intigua/antlr4/autosuggest/TrainSuggesterTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intigua.antlr4.autosuggest
+
+import tech.mlsql.autosuggest.statement.TrainSuggester
+import tech.mlsql.autosuggest.{TokenPos, TokenPosType}
+
+import scala.collection.JavaConverters._
+
+/**
+ * 25/10/2021 hellozepp(lisheng.zhanglin@163.com)
+ */
+class TrainSuggesterTest extends BaseTest {
+  test("run c[cursor]") {
+    val statement = context.lexer.tokenizeNonDefaultChannel(
+      """
+        | -- yes
+        | run c
+        |""".stripMargin).tokens.asScala.toList
+
+    val suggestions = new TrainSuggester(context, statement, TokenPos(1, TokenPosType.CURRENT, 1)).suggest()
+    assert(suggestions.map(_.name).toSet == Set("command as "))
+  }
+
+  test("run command as Cache[cursor]") {
+    val statement = context.lexer.tokenizeNonDefaultChannel(
+      """
+        | -- yes
+        | run command as Cache
+        |""".stripMargin).tokens.asScala.toList
+
+    val suggestions = new TrainSuggester(context, statement, TokenPos(3, TokenPosType.CURRENT, 5)).suggest()
+    assert(suggestions.map(_.name).toSet == Set("CacheExt.`` "))
+  }
+
+  test("run command as CacheExt.`` w[cursor]") {
+    val statement = context.lexer.tokenizeNonDefaultChannel(
+      """
+        | -- yes
+        | run command as CacheExt.`` w
+        |""".stripMargin).tokens.asScala.toList
+
+    val suggestions = new TrainSuggester(context, statement, TokenPos(6, TokenPosType.CURRENT, 1)).suggest()
+    assert(suggestions.map(_.name).toSet == Set("where ", "options "))
+  }
+}


### PR DESCRIPTION
MLSQL run/train automatic syntax prompt
background
Currently, we support the four grammars of load/select/save/set, and this time we will access the run/train grammar prompts.
run/train basic application
The usage of run/train grammar is listed below, and specific grammar hints will be designed according to the usage method:
```
load json.`/tmp/train` as trainData;

train trainData as RandomForest.`/tmp/rf` where
keepVersion="true"
and fitParam.0.featuresCol="content"
and fitParam.0.labelCol="label"
and fitParam.0.maxDepth="4"
and fitParam.0.checkpointInterval="100"
and fitParam.0.numTrees="4"
;
```

Grammar tips
1. Virtual table prompt (train/run [tempTable])

2. Data source tips
- During pre-processing, all data source temporary tables are parsed and cached in the cache of `StatementTempTableProvider`, and then the data source temporary table is prompted after the run command, for example: `run [temp table] as HDFSCommand...`
- cmmand, for example: `run [command] as HDFSCommand...`

3. As keyword hint
- The as keyword of the data source: train trainData [as]
- The as keyword of the output table: An example is shown below.
```
run command as HDFSCommand.`` where parameters='''["-ls","/tmp"]''' [as] hdfsTable;
```


4. ET source prompt (only show the implementation of the train method)
- For example: `run command as [HDFSCommand]...`

5. Where keyword hints
- For example: `run command as HDFSCommand w[here]`

6. Options keyword hint
- For example: `run command as HDFSCommand [pption]`

7. Prompt for common parameters of where conditions
- Grouping parameters
- Non-grouping parameters

8. Where conditions depend on parameter prompts: Not implemented in this issue
- Dynamic dependency (DYNAMIC_BIND): In order to describe more complex dependencies, such as value dependency, compound condition dependency, dynamic field dependency, etc. Therefore, the dependency relationship is described by SQL, which enables flexible development and access to parameter dependencies. When in use, it needs to dynamically generate dependency calculation sql according to the dependent field depends, and calculate the dependency relationship according to the returned result of sql.
- Static dependency (STATIC_BIND)
- Group dependency (GROUP_BIND)
  - Group dependency needs to be removed fitParam.[tag__${tag.field}__${tag.tag}]. Prefix only keep field